### PR TITLE
Fix

### DIFF
--- a/particles/outputs/load_balancer/canonical_hosted_zone_name_id.hbs
+++ b/particles/outputs/load_balancer/canonical_hosted_zone_name_id.hbs
@@ -1,4 +1,4 @@
 {{#output "m:core" "base"}}
-  "Value": {"Fn::GetAtt" : [ "{{loadBalancerLogicalId}}", "CanonicalHostedZoneNameId" ]},
+  "Value": {"Fn::GetAtt" : [ "{{loadBalancerLogicalId}}", "CanonicalHostedZoneNameID" ]},
   "Description": "The ID of the Amazon Route 53 hosted zone name that is associated with {{instanceLogicalId}}"
 {{/output}}


### PR DESCRIPTION
ValidationError: Template error: resource ElasticLoadBalancer does not support attribute type CanonicalHostedZoneNameId in Fn::GetAtt
